### PR TITLE
(PXP-6617): remove scopes from jwt aud claim

### DIFF
--- a/authutils/errors.go
+++ b/authutils/errors.go
@@ -38,9 +38,9 @@ func expired(timestamp int64) error {
 	return errors.New(msg)
 }
 
-func missingAudience(missingAud string, containsAuds []string) error {
-	containsString := strings.Join(containsAuds, ", ")
-	msg := fmt.Sprintf("token missing required audience: %s; contains: %s\n", missingAud, containsString)
+func missingScope(missingScope string, containsScopes []string) error {
+	containsString := strings.Join(containsScopes, ", ")
+	msg := fmt.Sprintf("token missing required scope: %s; contains: %s\n", missingScope, containsString)
 	return errors.New(msg)
 }
 

--- a/authutils/errors.go
+++ b/authutils/errors.go
@@ -43,3 +43,7 @@ func missingAudience(missingAud string, containsAuds []string) error {
 	msg := fmt.Sprintf("token missing required audience: %s; contains: %s\n", missingAud, containsString)
 	return errors.New(msg)
 }
+
+func missingKey(keyID string) error {
+	return fmt.Errorf("no key exists with ID: %s", keyID)
+}

--- a/authutils/keys.go
+++ b/authutils/keys.go
@@ -2,6 +2,7 @@ package authutils
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	jose "gopkg.in/square/go-jose.v2"
@@ -69,7 +70,7 @@ func (manager *KeysManager) Refresh() error {
 	// Get the JSON response from the URL configured in the manager.
 	resp, err := http.Get(manager.URL)
 	if err != nil {
-		return err
+		return fmt.Errorf("couldn't get keys from %s: %s", manager.URL, err.Error())
 	}
 
 	// Parse the response JSON into a jose.JSONWebKeySet.

--- a/authutils/keys.go
+++ b/authutils/keys.go
@@ -2,8 +2,6 @@ package authutils
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"net/http"
 
 	jose "gopkg.in/square/go-jose.v2"
@@ -41,7 +39,7 @@ func (manager *KeysManager) Lookup(keyID string) (*jose.JSONWebKey, error) {
 		jwk, exists = manager.KeyMap[keyID]
 		// If still no key is found, return an error.
 		if !exists {
-			return jwk, errors.New(fmt.Sprintf("no key exists with ID: %s", keyID))
+			return nil, missingKey(keyID)
 		}
 	}
 	return jwk, nil

--- a/authutils/test_utils.go
+++ b/authutils/test_utils.go
@@ -78,10 +78,10 @@ func publicKeyToJWK(keyID string, publicKey *rsa.PublicKey) jose.JSONWebKey {
 func makeDefaultClaims() Claims {
 	exp := int(time.Now().Unix() + 1000)
 	exampleClaims := Claims{
-		"aud": []string{"test"},
-		"iss": "https://example-iss.net",
-		"exp": exp,
-		"pur": "access",
+		"scope": []string{"test"},
+		"iss":   "https://example-iss.net",
+		"exp":   exp,
+		"pur":   "access",
 	}
 
 	return exampleClaims
@@ -92,7 +92,7 @@ func makeDefaultExpected() Expected {
 	now := time.Now().Unix()
 	exp := &now
 	expected := Expected{
-		Audiences:  []string{"test"},
+		Scopes:     []string{"test"},
 		Issuers:    []string{"https://example-iss.net"},
 		Expiration: exp,
 		Purpose:    &purpose,

--- a/authutils/test_utils.go
+++ b/authutils/test_utils.go
@@ -89,10 +89,12 @@ func makeDefaultClaims() Claims {
 
 func makeDefaultExpected() Expected {
 	purpose := "access"
+	now := time.Now().Unix()
+	exp := &now
 	expected := Expected{
 		Audiences:  []string{"test"},
 		Issuers:    []string{"https://example-iss.net"},
-		Expiration: time.Now().Unix(),
+		Expiration: exp,
 		Purpose:    &purpose,
 	}
 	return expected

--- a/authutils/validate.go
+++ b/authutils/validate.go
@@ -110,6 +110,10 @@ func checkIssuer(claims *Claims, allowed []string) error {
 
 // checkScope validates the `scope` field in the claims.
 func checkScope(claims *Claims, expected []string) error {
+	// if token has a scope field but no scopes are expected this is fine
+	if len(expected) == 0 {
+		return nil
+	}
 	tokenScope, exists := (*claims)["scope"]
 	if !exists {
 		return missingField("scope")

--- a/authutils/validate.go
+++ b/authutils/validate.go
@@ -168,19 +168,10 @@ type Expected struct {
 	Purpose *string `json:"pur"`
 }
 
-// selfValidate ensures that the fields provided in Expected are valid. For
-// example, to validate some Claims the validator must identify with at least
-// one audience (`aud`) in the claims, so these may not be empty.
-//
 // See https://tools.ietf.org/html/rfc7519 for general information on JWTs and
 // basic validation, and see https://tools.ietf.org/html/rfc7523 for
 // considerations for validation specific to using JWTs for the OAuth2 flow.
 func (expected *Expected) selfValidate() error {
-	// Must expect at least one audience.
-	if len(expected.Audiences) == 0 {
-		return validationError("must validate against at least one audience")
-	}
-
 	if expected.Purpose != nil {
 		// Must expect one of these given purposes.
 		if !contains(*expected.Purpose, ALLOWED_PURPOSES) {

--- a/authutils/validate.go
+++ b/authutils/validate.go
@@ -108,30 +108,30 @@ func checkIssuer(claims *Claims, allowed []string) error {
 	return nil
 }
 
-// checkAudience validates the `aud` field in the claims.
-func checkAudience(claims *Claims, expected []string) error {
-	tokenAud, exists := (*claims)["aud"]
+// checkScope validates the `scope` field in the claims.
+func checkScope(claims *Claims, expected []string) error {
+	tokenScope, exists := (*claims)["scope"]
 	if !exists {
-		return missingField("aud")
+		return missingField("scope")
 	}
-	var aud []string
-	switch a := tokenAud.(type) {
+	var scope []string
+	switch a := tokenScope.(type) {
 	case []string:
-		aud = a
+		scope = a
 	case []interface{}:
 		for _, value := range a {
 			valueString, casted := value.(string)
 			if !casted {
-				return fieldTypeError("aud", tokenAud, "[]string")
+				return fieldTypeError("scope", tokenScope, "[]string")
 			}
-			aud = append(aud, valueString)
+			scope = append(scope, valueString)
 		}
 	default:
-		return fieldTypeError("aud", tokenAud, "[]string")
+		return fieldTypeError("scope", tokenScope, "[]string")
 	}
-	for _, expectedAud := range expected {
-		if !contains(expectedAud, aud) {
-			return missingAudience(expectedAud, aud)
+	for _, expectedScope := range expected {
+		if !contains(expectedScope, scope) {
+			return missingScope(expectedScope, scope)
 		}
 	}
 	return nil
@@ -157,8 +157,8 @@ func checkPurpose(claims *Claims, expected *string) error {
 // Expected represents some values which are used to validate the claims in a
 // token.
 type Expected struct {
-	// Audiences is a list of expected receivers or uses of the token.
-	Audiences []string `json:"aud"`
+	// Scopes is a list of expected uses of the token.
+	Scopes []string `json:"scope"`
 	// Expiration is the Unix timestamp at which the token becomes expired.
 	Expiration *int64 `json:"exp"`
 	// Issuers is a list of acceptable issuers to expect tokens to contain.
@@ -212,7 +212,7 @@ func (expected *Expected) Validate(claims *Claims) error {
 	if err := checkIssuer(claims, expected.Issuers); err != nil {
 		return err
 	}
-	if err := checkAudience(claims, expected.Audiences); err != nil {
+	if err := checkScope(claims, expected.Scopes); err != nil {
 		return err
 	}
 	if err := checkPurpose(claims, expected.Purpose); err != nil {

--- a/authutils/validate_test.go
+++ b/authutils/validate_test.go
@@ -10,7 +10,6 @@ import (
 // REQUIRED_CLAIMS lists the claims which absolutely must appear in a token,
 // whose absence will cause it not to validate.
 var REQUIRED_CLAIMS []string = []string{
-	"aud",
 	"exp",
 	"iss",
 }


### PR DESCRIPTION
Jira Ticket: [PXP-6617](https://ctds-planx.atlassian.net/browse/PXP-6617)

Related Fence changes: https://github.com/uc-cdis/fence/pull/839

Unsure why feat/initial has not been merged. Arborist currently requires feat/initial. Mariner currently requires the current tip of master. 

### New Features
- Note: This PR also includes changes from the branch feat/initial, which improves handling around missing keys and fixes exp validation.

### Breaking Changes
- In step with Fence 5.0.0 changes to issued JWTs, in which scopes are moved out of the aud claim into a scopes claim, change JWT validation logic so that it does the same validation it was doing on the aud field, but does it on the scope field instead. 
- Do not require a scope claim to be present in the JWT if the calling function does not pass a required scope.

### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
