### PR TITLE
Add workflow to make patch releases on labeled PR merge

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,53 @@
+name: Make patch release
+
+# Make new release when a PR is merged that has the `release` label.
+# Only works for bumping patch version--see bump_version step.
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  make-patch-release-if-release-label:
+    name: Make patch release if release label
+    runs-on: ubuntu-latest
+    if: contains( github.event.pull_request.labels.*.name, 'release')
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: 'Get Previous tag'
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@master"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: fix remote
+        run: git remote set-url origin https://github.com/uc-cdis/go-authutils.git
+      - name: switch to master branch
+        run: git checkout master
+      - name: Bump release version
+        id: bump_version
+        uses: christian-draeger/increment-semantic-version@1.0.0
+        with:
+          current-version: ${{ steps.previoustag.outputs.tag }}
+          version-fragment: 'bug'
+      - name: Install python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name: Install Gen3 release-helper$
+        run: |
+          pip install wheel
+          python --version
+          pip install --user --editable git+https://github.com/uc-cdis/release-helper.git@master#egg=gen3git
+          python -m gen3git --github-access-token ${{ secrets.GITHUB_TOKEN }} tag ${{ steps.bump_version.outputs.next-version }}
+          python -m gen3git --github-access-token ${{ secrets.GITHUB_TOKEN }} --from-tag ${{ steps.previoustag.outputs.tag }} release
+          python -m gen3git --github-access-token ${{ secrets.GITHUB_TOKEN }} --from-tag ${{ steps.previoustag.outputs.tag }} gen --markdown
+          cat release_notes.md
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.bump_version.outputs.next-version }}
+          artifacts: "release.tar.gz,foo/*.txt"
+          bodyFile: "release_notes.md"
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

Jira Ticket: n/a

Taking this PyPFB workflow as a model. https://github.com/uc-cdis/pypfb/blob/6b1d58fe358d6b5cd70eb775a742a0eb37104b2c/.github/workflows/release.yaml


### New Features
Add workflow to make patch releases when a PR is merged that has the "release" label. 

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
