### PR TITLE
Re-add validate audience 

### DIFF
--- a/.github/workflows/golang-ci-workflow.yaml
+++ b/.github/workflows/golang-ci-workflow.yaml
@@ -12,4 +12,4 @@ jobs:
       - name: Run tests, lint code, install goveralls
         uses: uc-cdis/.github/.github/actions/golang-ci@master
         with:
-          GO_VERSION: "1.17"
+          GO_VERSION: "1.26.4"

--- a/authutils/errors.go
+++ b/authutils/errors.go
@@ -38,6 +38,12 @@ func expired(timestamp int64) error {
 	return errors.New(msg)
 }
 
+func missingAudience(missingAud string, containsAuds []string) error {
+	containsString := strings.Join(containsAuds, ", ")
+	msg := fmt.Sprintf("token missing required audience: %s; contains: %s\n", missingAud, containsString)
+	return errors.New(msg)
+}
+
 func missingScope(missingScope string, containsScopes []string) error {
 	containsString := strings.Join(containsScopes, ", ")
 	msg := fmt.Sprintf("token missing required scope: %s; contains: %s\n", missingScope, containsString)

--- a/authutils/test_utils.go
+++ b/authutils/test_utils.go
@@ -84,6 +84,7 @@ func publicKeyToJWK(keyID string, publicKey *rsa.PublicKey) jose.JSONWebKey {
 func makeDefaultClaims() Claims {
 	exp := int(time.Now().Unix() + 1000)
 	exampleClaims := Claims{
+		"aud":   []string{DEFAULT_TOKEN_AUDIENCE},
 		"scope": []string{"test"},
 		"iss":   "https://example-iss.net",
 		"exp":   exp,
@@ -98,6 +99,7 @@ func makeDefaultExpected() Expected {
 	now := time.Now().Unix()
 	exp := &now
 	expected := Expected{
+		Audiences:  []string{DEFAULT_TOKEN_AUDIENCE},
 		Scopes:     []string{"test"},
 		Issuers:    []string{"https://example-iss.net"},
 		Expiration: exp,

--- a/authutils/test_utils.go
+++ b/authutils/test_utils.go
@@ -84,7 +84,7 @@ func publicKeyToJWK(keyID string, publicKey *rsa.PublicKey) jose.JSONWebKey {
 func makeDefaultClaims() Claims {
 	exp := int(time.Now().Unix() + 1000)
 	exampleClaims := Claims{
-		"aud":   []string{DEFAULT_TOKEN_AUDIENCE},
+		"aud":   []string{"gen3", "user"},
 		"scope": []string{"test"},
 		"iss":   "https://example-iss.net",
 		"exp":   exp,
@@ -99,7 +99,7 @@ func makeDefaultExpected() Expected {
 	now := time.Now().Unix()
 	exp := &now
 	expected := Expected{
-		Audiences:  []string{DEFAULT_TOKEN_AUDIENCE},
+		Audiences:  []string{"gen3"},
 		Scopes:     []string{"test"},
 		Issuers:    []string{"https://example-iss.net"},
 		Expiration: exp,

--- a/authutils/validate.go
+++ b/authutils/validate.go
@@ -12,6 +12,7 @@ import (
 // `fence`-specific: the `pur` field indicates the purpose for the token, which
 // may also be validated. If used, it must take one of these values.
 var ALLOWED_PURPOSES []string = []string{"id", "access", "refresh", "session", "api_key"}
+var DEFAULT_TOKEN_AUDIENCE = "gen3"
 
 // JWTApplication stores the state for an application needing to validate JWTs.
 type JWTApplication struct {
@@ -141,6 +142,40 @@ func checkScope(claims *Claims, expected []string) error {
 	return nil
 }
 
+// checkAudience validates the `aud` field in the claims.
+func checkAudience(claims *Claims, expected []string) error {
+	// if token has an aud field but no audiences are expected this is fine
+	if len(expected) == 0 {
+		// Fallback to DEFAULT_TOKEN_AUDIENCE if no JWT audience is provided.
+		expected = []string{DEFAULT_TOKEN_AUDIENCE}
+	}
+	tokenAud, exists := (*claims)["aud"]
+	if !exists {
+		return missingField("aud")
+	}
+	var aud []string
+	switch a := tokenAud.(type) {
+	case []string:
+		aud = a
+	case []interface{}:
+		for _, value := range a {
+			valueString, casted := value.(string)
+			if !casted {
+				return fieldTypeError("aud", tokenAud, "[]string")
+			}
+			aud = append(aud, valueString)
+		}
+	default:
+		return fieldTypeError("aud", tokenAud, "[]string")
+	}
+	for _, expectedAud := range expected {
+		if !contains(expectedAud, aud) {
+			return missingAudience(expectedAud, aud)
+		}
+	}
+	return nil
+}
+
 func checkPurpose(claims *Claims, expected *string) error {
 	if expected != nil {
 		tokenPur, exists := (*claims)["pur"]
@@ -161,6 +196,8 @@ func checkPurpose(claims *Claims, expected *string) error {
 // Expected represents some values which are used to validate the claims in a
 // token.
 type Expected struct {
+	// Audiences is a list of expected receivers or uses of the token.
+	Audiences []string `json:"aud"`
 	// Scopes is a list of expected uses of the token.
 	Scopes []string `json:"scope"`
 	// Expiration is the Unix timestamp at which the token becomes expired.
@@ -208,6 +245,9 @@ func (expected *Expected) Validate(claims *Claims) error {
 		return err
 	}
 	if err := checkScope(claims, expected.Scopes); err != nil {
+		return err
+	}
+	if err := checkAudience(claims, expected.Audiences); err != nil {
 		return err
 	}
 	if err := checkPurpose(claims, expected.Purpose); err != nil {

--- a/authutils/validate.go
+++ b/authutils/validate.go
@@ -12,7 +12,6 @@ import (
 // `fence`-specific: the `pur` field indicates the purpose for the token, which
 // may also be validated. If used, it must take one of these values.
 var ALLOWED_PURPOSES []string = []string{"id", "access", "refresh", "session", "api_key"}
-var DEFAULT_TOKEN_AUDIENCE = "gen3"
 
 // JWTApplication stores the state for an application needing to validate JWTs.
 type JWTApplication struct {
@@ -146,8 +145,7 @@ func checkScope(claims *Claims, expected []string) error {
 func checkAudience(claims *Claims, expected []string) error {
 	// if token has an aud field but no audiences are expected this is fine
 	if len(expected) == 0 {
-		// Fallback to DEFAULT_TOKEN_AUDIENCE if no JWT audience is provided.
-		expected = []string{DEFAULT_TOKEN_AUDIENCE}
+		return nil
 	}
 	tokenAud, exists := (*claims)["aud"]
 	if !exists {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/uc-cdis/go-authutils
 
-go 1.17
+go 1.26.4
 
 require github.com/go-jose/go-jose/v3 v3.0.4
 


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: [MIDRC-1305](https://ctds-planx.atlassian.net/browse/MIDRC-1305)

Reverts some of the changes from https://github.com/uc-cdis/go-authutils/pull/3 in order to validate the aud again

### New Features

### Breaking Changes
* The `aud` field of JWT tokens is validated again. Tokens without a matching `aud` claim will fail validation. No validation on `aud` is performed if expected `aud` is nil. 
### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->


[MIDRC-1305]: https://ctds-planx.atlassian.net/browse/MIDRC-1305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ